### PR TITLE
[BTFS-1155] - fixed json error to render languages

### DIFF
--- a/public/locales/da/settings.json
+++ b/public/locales/da/settings.json
@@ -63,22 +63,17 @@
       "details": "Lagrer JavaScript fejlmeddelser og stack-traces som opstår når App'en benyttes, i tilfælde hvor det er muligt. Det er til stor gavn at vide når App'en ikke fungerer for dig, men <1>fejlmeddelser kan inkludere identificerbar information</1> som CID'er eller fil-stier, så slå det kun til, hvis du er komfortabel med at dele denne information med os."
     }
   },
-<<<<<<< HEAD
-  "ipfsCmdTools": "BTFS kommandolinje værktøjer",
-  "ipfsCmdToolsDescription": "Add <0>btfs</0> binary to your system <0>PATH</0> so you can use it in the command line."
-=======
   "Experiments": {
-    "description": "Her kan du få et tidligt smugkig på nye IPFS funktioner ved at tilvælge mulighederne neden for. Vi afprøver disse idéer og de er muligvis ikke perfekte vi vil elske at høre din feedback.",
+    "description": "Her kan du få et tidligt smugkig på nye BTFS funktioner ved at tilvælge mulighederne neden for. Vi afprøver disse idéer og de er muligvis ikke perfekte vi vil elske at høre din feedback.",
     "issueUrl": "Åben en sag",
     "feedbackUrl": "💌Efterlad feedback",
     "readMoreUrl": "Læs mere",
     "npmOnIpfs": {
-      "title": "NPM på IPFS",
+      "title": "NPM på BTFS",
       "label": "Slå ipfs-npm til",
-      "description": "Installér npm moduler via IPFS med 'ipfs-npm' kommandolinje værktøjet!"
+      "description": "Installér npm moduler via BTFS med 'btfs-npm' kommandolinje værktøjet!"
     }
   },
-  "ipfsCmdTools": "IPFS kommandolinje værktøjer",
+  "ipfsCmdTools": "BTFS kommandolinje værktøjer",
   "ipfsCmdToolsDescription": "Tilføj <0>ipfs</0> binære fil til dit system's <0>PATH</0> så du kan benytte det via kommandolinjen."
->>>>>>> v2.4.7
 }

--- a/public/locales/en/settings.json
+++ b/public/locales/en/settings.json
@@ -64,7 +64,7 @@
     }
   },
   "ipfsCmdTools": "BTFS command line tools",
-  "ipfsCmdToolsDescription": "Add <0>btfs</0> binary to your system <0>PATH</0> so you can use it in the command line."
+  "ipfsCmdToolsDescription": "Add <0>btfs</0> binary to your system <0>PATH</0> so you can use it in the command line.",
   "Experiments": {
     "description": "Here you can get an early preview into new IPFS features by enabling options below. We are testing these ideas, and they may not be perfect yet so we'd love to hear your feedback.",
     "issueUrl": "Open an issue",

--- a/public/locales/fr/settings.json
+++ b/public/locales/fr/settings.json
@@ -64,16 +64,16 @@
     }
   },
   "ipfsCmdTools": "BTFS outils en ligne de commandes",
-  "ipfsCmdToolsDescription": "Ajouter<0>btfs</0>éxécutable sur votre système <0>PATH</0>vous pouvez utilisé cela en ligne de commande. "
+  "ipfsCmdToolsDescription": "Ajouter<0>btfs</0>éxécutable sur votre système <0>PATH</0>vous pouvez utilisé cela en ligne de commande. ",
   "Experiments": {
-    "description": "Ici vous pouvez avoir un aperçu des nouvelles fonctionnalités de IPFS en activant les options ci-dessous. Nous testons de nouvelles idées, et elles peuvent ne pas encore être parfaites donc on serait heureux d'avoir votre avis.",
+    "description": "Ici vous pouvez avoir un aperçu des nouvelles fonctionnalités de BTFS en activant les options ci-dessous. Nous testons de nouvelles idées, et elles peuvent ne pas encore être parfaites donc on serait heureux d'avoir votre avis.",
     "issueUrl": "Ouvrir une issue Github",
     "feedbackUrl": "💌Laisser un commentaire",
     "readMoreUrl": "En savoir plus",
     "npmOnIpfs": {
-      "title": "NPM sur IPFS",
-      "label": "Activer ipfs-npm",
-      "description": "Installer les modules npm via IPFS avec l'outil en lignes de commande \"ipfs-npm\"!"
+      "title": "NPM sur BTFS",
+      "label": "Activer btfs-npm",
+      "description": "Installer les modules npm via BTFS avec l'outil en lignes de commande \"ipfs-npm\"!"
     }
   }
 }

--- a/public/locales/no/settings.json
+++ b/public/locales/no/settings.json
@@ -64,16 +64,16 @@
     }
   },
   "ipfsCmdTools": "BTFS command line tools",
-  "ipfsCmdToolsDescription": "Add <0>btfs</0> binary to your system <0>PATH</0> so you can use it in the command line."
+  "ipfsCmdToolsDescription": "Add <0>btfs</0> binary to your system <0>PATH</0> so you can use it in the command line.",
   "Experiments": {
     "description": "Here you can get an early preview into new IPFS features by enabling options below. We are testing these ideas, and they may not be perfect yet so we'd love to hear your feedback.",
     "issueUrl": "Open an issue",
     "feedbackUrl": "💌Leave feedback",
     "readMoreUrl": "Read More",
     "npmOnIpfs": {
-      "title": "NPM on IPFS",
-      "label": "Enable ipfs-npm",
-      "description": "Install npm modules through IPFS with the 'ipfs-npm' command line tool!"
+      "title": "NPM on BTFS",
+      "label": "Enable btfs-npm",
+      "description": "Install npm modules through BTFS with the 'btfs-npm' command line tool!"
     }
   }
 }

--- a/public/locales/pt/settings.json
+++ b/public/locales/pt/settings.json
@@ -64,16 +64,16 @@
     }
   },
   "ipfsCmdTools": "Ferramentas de linha de comandos BTFS",
-  "ipfsCmdToolsDescription": "Adicione o binário <0>btfs</0> ao <0>PATH</0> do seu sistema para que o possa usar na sua linha de comandos."
+  "ipfsCmdToolsDescription": "Adicione o binário <0>btfs</0> ao <0>PATH</0> do seu sistema para que o possa usar na sua linha de comandos.",
   "Experiments": {
-    "description": "Aqui pode experimentar novas funcionalidades do IPFS ativando as opções abaixo. Estamos a testar estas ideias e estas ainda podem não estar perfeitas por isso gostaríamos de saber a sua opinião.",
+    "description": "Aqui pode experimentar novas funcionalidades do BTFS ativando as opções abaixo. Estamos a testar estas ideias e estas ainda podem não estar perfeitas por isso gostaríamos de saber a sua opinião.",
     "issueUrl": "Abrir um relatório de erros",
     "feedbackUrl": "💌Deixar um comentário",
     "readMoreUrl": "Ler mais",
     "npmOnIpfs": {
-      "title": "NPM em IPFS",
-      "label": "Ativar ipfs-npm",
-      "description": "Instale os módulos npm através do IPFS com a ferramenta da linha de comandos 'ipfs-npm'!"
+      "title": "NPM em BTFS",
+      "label": "Ativar BTfs-npm",
+      "description": "Instale os módulos npm através do BTFS com a ferramenta da linha de comandos 'btfs-npm'!"
     }
   }
 }


### PR DESCRIPTION
Config description needs update. The config description in English should read: "The BTFS config file is a json document. It is read once when the BTFS daemon is started. Save your changes then restart the BTFS daemon to apply them."

“title” should read "Settings"

actions.edit should read "Change"